### PR TITLE
Add more safe default extensions to package.yaml template

### DIFF
--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -18,8 +18,10 @@ ghc-options:
 
 default-extensions:
   - AllowAmbiguousTypes
+  - ApplicativeDo
   - BlockArguments
   - DataKinds
+  - DeriveAnyClass
   - DeriveFoldable
   - DeriveFunctor
   - DeriveGeneric
@@ -28,6 +30,8 @@ default-extensions:
   - FlexibleContexts
   - FlexibleInstances
   - FunctionalDependencies
+  - GADTs
+  - GeneralizedNewtypeDeriving
   - ImportQualifiedPost
   - ImpredicativeTypes
   - InstanceSigs
@@ -38,8 +42,14 @@ default-extensions:
   - NamedFieldPuns
   - NumericUnderscores
   - OverloadedStrings
+  - PatternSynonyms
+  - PolyKinds
+  - RankNTypes
   - RecordWildCards
+  - RecursiveDo
   - ScopedTypeVariables
   - StandaloneDeriving
+  - StandaloneKindSignatures
   - TypeApplications
+  - TypeFamilies
   - ViewPatterns


### PR DESCRIPTION
Figured the template might as well include the full set of good default extensions. This is a bit opinionated - `-XDeriveAnyClass` will break existing code if the strategy is ambiguous (e.g. if `-XGeneralizedNewtypeDeriving` is on, which it is now). 

There are some other extensions implied by these additions:
  - `-XPolyKinds` implies `-XKindSignatures`
  - `-XTypeFamilies` implies `-XMonoLocalBinds` (so it can be removed), `-XKindSignatures`, `-XExplicitNamespaces`.

if these are ok, should we add `-XTypeOperators` too? It's pretty useful but isn't that commonly used outside of cursed sicko code (my preferred style). 
